### PR TITLE
Fix sloth start-up

### DIFF
--- a/sloth/gui/labeltool.py
+++ b/sloth/gui/labeltool.py
@@ -133,7 +133,7 @@ class MainWindow(QMainWindow):
 
         img = self.labeltool.getImage(new_image)
 
-        if img == None:
+        if img is None:
             self.controls.setFilename("")
             self.selectionmodel.setCurrentIndex(new_image.index(), QItemSelectionModel.ClearAndSelect|QItemSelectionModel.Rows)
             return


### PR DESCRIPTION
This fixes failing sloth start-up with Qt5  "ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()"

Tested on Python 3.5.2 and 3.6.3